### PR TITLE
Add some specific replacements for place --> joint

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -78,5 +78,40 @@
       "repB": "later",
       "type": "Simple"
     }
+    {
+      "active": true,
+      "case": "Maintain",
+      "repA": "place.",
+      "repB": "joint.",
+      "type": "Simple"
+    }
+    {
+      "active": true,
+      "case": "Maintain",
+      "repA": "place is",
+      "repB": "joint is",
+      "type": "Simple"
+    }
+    {
+      "active": true,
+      "case": "Maintain",
+      "repA": "place was",
+      "repB": "joint was",
+      "type": "Simple"
+    }
+    {
+      "active": true,
+      "case": "Maintain",
+      "repA": "place has",
+      "repB": "joint has",
+      "type": "Simple"
+    }
+    {
+      "active": true,
+      "case": "Maintain",
+      "repA": "place,",
+      "repB": "joint,",
+      "type": "Simple"
+    }
   ]
 }


### PR DESCRIPTION
Didn't want to get to global here, but this should cover any references to the taco joint, the steak joint, or the kayak rental joint, provided you use Oxford commas when comparing two different joints.
